### PR TITLE
Make Vite base path relative to deployment directory

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,3 @@
 export default {
-  base: "/qaboom/",
+  base: "",
 };


### PR DESCRIPTION
The current base path requires the directory from which the app is served to be called `/qaboom`, i.e. a direct sub-folder of the web servers root called `qaboom`. This unnecessarily limits the ways the app is deployed and may make certain deployments impossible depending on the environment.

This patch changes the base path such that all required files are loaded relative the app's deployment directory.